### PR TITLE
Implement return book wizard and modern build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+project(ils LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt5 COMPONENTS Widgets Sql Network REQUIRED)
+
+set(SOURCES
+    main.cpp
+    welcome.cpp
+    mainwindow.cpp
+    books.cpp
+    addbook.cpp
+    issuebook.cpp
+    admin.cpp
+    members.cpp
+    connectdb.cpp
+    wizards/editbookwizard.cpp
+    wizards/addcopywizard.cpp
+    wizards/returnbookwizarad.cpp
+    wizards/summarywizard.cpp
+    wizards/addbookwizard.cpp
+    wizards/bookinfoonline.cpp
+    wizards/addmemberwizard.cpp
+    wizards/issuebookwizard.cpp
+)
+
+qt5_add_resources(QRC_SOURCES resources.qrc)
+
+add_executable(${PROJECT_NAME} ${SOURCES} ${QRC_SOURCES})
+
+target_link_libraries(${PROJECT_NAME} Qt5::Widgets Qt5::Sql Qt5::Network)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
+# Integrated Library System
 
-Integrated Library System 
-using C++ and Qt
+This project is a Qt based application for managing a small library. It was originally built with qmake but now provides a modern **CMake** build system.
 
+## Building
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+The resulting executable is `build/ils`. Pass a custom database path as the first argument or place `ils.sqlite` next to the executable.
+
+```bash
+./ils /path/to/ils.sqlite
+```

--- a/main.cpp
+++ b/main.cpp
@@ -4,8 +4,7 @@
 #include <QtCore>
 #include <memory>
 
-//#define PATH_TO_DB "/home/srn/Desktop/ils/ils/ils.sqlite"
-#define PATH_TO_DB "/home/srn/Documents/ils/ils.sqlite"
+
 
 
 using namespace std;
@@ -20,7 +19,8 @@ int main(int argc, char *argv[])
 
 
 
-    ConnectDB db(PATH_TO_DB);
+    QString dbPath = (argc > 1) ? argv[1] : QString("ils.sqlite");
+    ConnectDB db(dbPath);
 
     Welcome w;
     MainWindow mw;

--- a/members.cpp
+++ b/members.cpp
@@ -128,10 +128,17 @@ void Members::addMember()
 }
 void Members::returnBook()
 {
-    ReturnBookWizarad *rrbw = rbw;
+    QModelIndex idx = membersTable->currentIndex();
+    if(!idx.isValid())
+        return;
 
+    QSqlRecord record = model->record(idx.row());
+    QString roll = record.value("Roll").toString();
+
+    ReturnBookWizarad *old = rbw;
     rbw = new ReturnBookWizarad(this);
-    delete rrbw;
+    rbw->setMemberRoll(roll);
+    delete old;
 
     rbw->show();
 }

--- a/wizards/returnbookwizarad.cpp
+++ b/wizards/returnbookwizarad.cpp
@@ -1,12 +1,30 @@
+#include <QSqlRecord>
 #include "returnbookwizarad.h"
 
 ReturnBookWizarad::ReturnBookWizarad(QWidget *parent) :
     QWizard(parent)
 {
-    addPage(new SelectBookPage);
+    addPage(&sbp);
+    addPage(&rfp);
+    setButtonText(QWizard::FinishButton, "Return Book");
 }
+
+void ReturnBookWizarad::setMemberRoll(const QString &roll)
+{
+    m_memberRoll = roll;
+    sbp.setMember(roll);
+}
+
 void ReturnBookWizarad::accept()
 {
+    QString bookNo = field("bookNo").toString();
+    QSqlQuery q;
+    q.exec(QString("SELECT memberID FROM members WHERE roll='%1'").arg(m_memberRoll));
+    if(q.next()) {
+        QString memberID = q.value(0).toString();
+        QSqlQuery del(QString("DELETE FROM issue WHERE memberID=%1 AND bookNo=%2").arg(memberID).arg(bookNo));
+        QSqlQuery upd(QString("UPDATE bookNumbers SET issued=0 WHERE bookNo=%1").arg(bookNo));
+    }
     QDialog::accept();
 }
 
@@ -20,6 +38,11 @@ SelectBookPage::SelectBookPage(QWidget *parent) :
     branchLabel.setText("Branch");
     booksTaken.setText("Books Taken");
 
+    roll.setReadOnly(true);
+    name.setReadOnly(true);
+    branch.setReadOnly(true);
+    selectedBookEdit.setVisible(false);
+
     layout.addWidget(&rollLabel,0,0);
     layout.addWidget(&roll,0,1);
     layout.addWidget(&nameLabel,0,2);
@@ -27,21 +50,50 @@ SelectBookPage::SelectBookPage(QWidget *parent) :
     layout.addWidget(&branchLabel,1,0);
     layout.addWidget(&branch,1,1);
     layout.addWidget(&booksTaken,2,0);
-    layout.addWidget(&issuedBooksTable,3,0,0,4);
-
+    layout.addWidget(&issuedBooksTable,3,0,1,4);
 
     setLayout(&layout);
+
+    registerField("bookNo", &selectedBookEdit);
+    connect(&issuedBooksTable, &QTableView::clicked, this, &SelectBookPage::rowSelected);
 }
 
-
-void SelectBookPage::getStudentInfo()
+void SelectBookPage::setMember(const QString &rollNo)
 {
+    roll.setText(rollNo);
+    QSqlQuery q;
+    q.prepare("SELECT memberID, Name, Branch FROM members WHERE roll=?");
+    q.addBindValue(rollNo);
+    if(q.exec() && q.next()) {
+        memberID = q.value(0).toString();
+        name.setText(q.value(1).toString());
+        branch.setText(q.value(2).toString());
+        model.setTable("issue");
+        model.setFilter(QString("memberID='%1'").arg(memberID));
+        model.select();
+        issuedBooksTable.setModel(&model);
+        issuedBooksTable.hideColumn(0);
+        issuedBooksTable.hideColumn(3);
+    }
+}
 
+void SelectBookPage::rowSelected(const QModelIndex &index)
+{
+    QSqlRecord r = model.record(index.row());
+    selectedBookEdit.setText(r.value("bookNo").toString());
+}
+
+int SelectBookPage::nextId() const
+{
+    return 1;
 }
 
 //====================================//
 ReturnFinalPage::ReturnFinalPage(QWidget *parent):
     QWizardPage(parent)
 {
-
+    setTitle("Return Book");
+    infoLabel.setText("Press Finish to return the selected book.");
+    layout.addWidget(&infoLabel);
+    setLayout(&layout);
 }

--- a/wizards/returnbookwizarad.h
+++ b/wizards/returnbookwizarad.h
@@ -12,9 +12,10 @@ class SelectBookPage : public QWizardPage
     Q_OBJECT
 public:
     explicit SelectBookPage(QWidget *parent = 0);
-    void getStudentInfo();
+    void setMember(const QString &roll);
+    int nextId() const;
 private:
-    QString bookID;
+    QString memberID;
     QLabel rollLabel;
     QLabel nameLabel;
     QLabel branchLabel;
@@ -26,7 +27,7 @@ private:
     QLineEdit name;
     QLineEdit branch;
 
-    mutable QLineEdit studentRollEdit; // invisible
+    QLineEdit selectedBookEdit; // invisible
 
 
     QTableView issuedBooksTable;
@@ -36,11 +37,11 @@ private:
 
 
     QGridLayout layout;
+private slots:
+    void rowSelected(const QModelIndex &index);
 
 
-signals:
 
-public slots:
 };
 // =========================== //
 class ReturnFinalPage : public QWizardPage
@@ -49,9 +50,10 @@ class ReturnFinalPage : public QWizardPage
 public:
     explicit ReturnFinalPage(QWidget *parent = 0);
 
-signals:
+private:
+    QLabel infoLabel;
+    QVBoxLayout layout;
 
-public slots:
 };
 
 
@@ -61,11 +63,16 @@ class ReturnBookWizarad : public QWizard
     Q_OBJECT
 public:
     explicit ReturnBookWizarad(QWidget *parent = 0);
+    void setMemberRoll(const QString &roll);
+    QString memberRoll() const { return m_memberRoll; }
     void accept();
-    
+
+private:
+    QString m_memberRoll;
+    SelectBookPage sbp;
+    ReturnFinalPage rfp;
 signals:
     
-public slots:
     
 };
 


### PR DESCRIPTION
## Summary
- add a `CMakeLists.txt` for building with CMake
- make database path configurable at runtime
- implement missing return book wizard logic
- hook up member table to launch the wizard
- document build steps in the README

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt5")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_6841500c9e2c832a817eb7237cb1fcc4